### PR TITLE
Don’t require a specific version of ext-xmlwriter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=5.3.3",
-		"ext-xmlwriter": ">=0.1"
+		"ext-xmlwriter": "*"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
We've used your package in one of our projects done using Laravel 5.6 on Ubuntu. When we run composer update, we get the following:

    -pdeans/xml-builder dev-master requires ext-xmlwriter >=0.1 -> 
    the requested PHP extension xmlwriter has the wrong version 
    (7.2.11-2+ubuntu16.04.1+deb.sury.org+1) installed.

The PR submitted simply removes the specific version requirement from the xmlwriter extension installed with PHP.